### PR TITLE
Handle StaleElementReferenceException(s)

### DIFF
--- a/Engine/TestEngine/src/com/redskyit/scriptDriver/RunTests.java
+++ b/Engine/TestEngine/src/com/redskyit/scriptDriver/RunTests.java
@@ -701,6 +701,7 @@ public class RunTests {
 					}
 				} catch(StaleElementReferenceException e) {
 					// element has gone stale, re-select it
+					System.out.println("// EXCEPTION : StaleElementReference");
 				}
 				sleepAndReselect(100);
 			} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -719,6 +720,7 @@ public class RunTests {
 					}
 				} catch(StaleElementReferenceException e) {
 					// element has gone stale, re-select it
+					System.out.println("// EXCEPTION : StaleElementReference");
 				}
 				sleepAndReselect(100);
 			} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -757,6 +759,7 @@ public class RunTests {
 								}
 							} catch(StaleElementReferenceException e) {
 								// element has gone stale, re-select it
+								System.out.println("// EXCEPTION : StaleElementReference");
 							}
 							sleepAndReselect(100);
 						} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -806,6 +809,7 @@ public class RunTests {
 								}
 							} catch(StaleElementReferenceException e) {
 								// element has gone stale, re-select it
+								System.out.println("// EXCEPTION : StaleElementReference");
 							}
 							sleepAndReselect(100);
 						} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -833,6 +837,7 @@ public class RunTests {
 						}
 					} catch(StaleElementReferenceException e) {
 						// element has gone stale, re-select it
+						System.out.println("// EXCEPTION : StaleElementReference");
 					}
 					sleepAndReselect(100);
 				} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -980,33 +985,41 @@ public class RunTests {
 	}
 
 	private void info(WebElement element, String selector, boolean verify) throws Exception {
-		try {
-			Point loc = element.getLocation();
-			Dimension size = element.getSize();
-			String tag = element.getTagName();
-			System.out.print(null == selector ? "test-id \"" + element.getAttribute("test-id") + "\"" : selector);
-			System.out.print(" info");
-			System.out.print(" tag " + tag);
-			System.out.print(" at " + loc.x + "," + loc.y);
-			System.out.print(" size " + size.width + "," + size.height);
-			System.out.print((element.isDisplayed() ? "" : " not") + " displayed");
-			System.out.print((element.isEnabled() ? "" : " not") + " enabled");
-			System.out.print((element.isSelected() ? "" : " not") + " selected");
-			if (tag.equals("input") || tag.equals("select")) {
-				System.out.print(" check \"" + element.getAttribute("value") + "\"");
-			} else {
-				if (tag.equals("textarea")) {
-					CRC32 crc = new CRC32();
-					crc.update(element.getAttribute("value").getBytes());
-					System.out.print(" checksum \"crc32:" + crc.getValue() + "\"");
+		do {
+			try {
+				Point loc = element.getLocation();
+				Dimension size = element.getSize();
+				String tag = element.getTagName();
+				System.out.print(null == selector ? "test-id \"" + element.getAttribute("test-id") + "\"" : selector);
+				System.out.print(" info");
+				System.out.print(" tag " + tag);
+				System.out.print(" at " + loc.x + "," + loc.y);
+				System.out.print(" size " + size.width + "," + size.height);
+				System.out.print((element.isDisplayed() ? "" : " not") + " displayed");
+				System.out.print((element.isEnabled() ? "" : " not") + " enabled");
+				System.out.print((element.isSelected() ? "" : " not") + " selected");
+				if (tag.equals("input") || tag.equals("select")) {
+					System.out.print(" check \"" + element.getAttribute("value") + "\"");
 				} else {
-					System.out.print(" check \"" + element.getText() + "\"");
+					if (tag.equals("textarea")) {
+						CRC32 crc = new CRC32();
+						crc.update(element.getAttribute("value").getBytes());
+						System.out.print(" checksum \"crc32:" + crc.getValue() + "\"");
+					} else {
+						System.out.print(" check \"" + element.getText() + "\"");
+					}
 				}
+				System.out.println();
+				return;
+			} catch(StaleElementReferenceException e) {
+				// element has gone stale, re-select it
+				System.out.println("// EXCEPTION : StaleElementReference");
+			} catch(Exception e) {
+				if (verify) throw e;
+				return;
 			}
-			System.out.println();
-		} catch(Exception e) {
-			if (verify) throw e;
-		}
+			sleepAndReselect(100);
+		}  while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
 	}
 
 	// Find all test-id fields, and dump their info
@@ -1033,12 +1046,22 @@ public class RunTests {
 	private void testContextValue(StreamTokenizer tokenizer, boolean checksum) throws Exception {
 		String tagName = context.getTagName();
 		if (tagName.equals("input") || tagName.equals("select") || tagName.equals("textarea")) { 
-			System.out.println("> Checking element value is equal to '" + tokenizer.sval + "'");
+			System.out.println("// Checking element value is equal to '" + tokenizer.sval + "'");
 			do {
-				String value = context.getAttribute("value");
-				if (_not != (null != value && compareStrings(value, tokenizer.sval, checksum))) {
-					_not = false;
-					return;
+				try {
+					String value = context.getAttribute("value");
+					if (_not != (null != value && compareStrings(value, tokenizer.sval, checksum))) {
+						_not = false;
+						return;
+					}
+					if (null == value) {
+						System.out.println("// " + tokenizer.sval + " VALUE IS NULL");				
+					} else {
+						System.out.println("// " + tokenizer.sval + " DOES NOT MATH " + value);
+					}
+				} catch(StaleElementReferenceException e) {
+					// element has gone stale, re-select it
+					System.out.println("// EXCEPTION : StaleElementReference");
 				}
 				sleepAndReselect(100);
 			} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -1052,8 +1075,14 @@ public class RunTests {
 						_not = false;
 						return;
 					}
+					if (null == value) {
+						System.out.println("// " + tokenizer.sval + " VALUE IS NULL");				
+					} else {
+						System.out.println("// " + tokenizer.sval + " DOES NOT MATH " + value);
+					}
 				} catch(StaleElementReferenceException e) {
 					// element has gone stale, re-select it
+					System.out.println("// EXCEPTION : StaleElementReference");
 				}
 				sleepAndReselect(100);
 			} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -1073,6 +1102,7 @@ public class RunTests {
 					return;
 				} catch(StaleElementReferenceException se) {
 					// element has gone stale, re-select it
+					System.out.println("// EXCEPTION : StaleElementReference");
 					e = se;
 				} catch(Exception ex) {
 					e = ex;
@@ -1090,6 +1120,7 @@ public class RunTests {
 	}
 	
 	private void sleepAndReselect(int ms) throws Exception {
+		System.out.println("// SLEEP AND RESELECT [wait=" + (_waitFor - (new Date()).getTime()) + "]");
 		Sleeper.sleepTight(ms);
 		try {
 			if (ctype == ContextType.XPath || ctype == ContextType.Field) {
@@ -1109,6 +1140,7 @@ public class RunTests {
 		} catch (Exception e) {
 			throw e;
 		}
+		System.out.println("// RESELECTED " + selector);
 	}
 
 	private void xpathContext(StreamTokenizer tokenizer) throws Exception {

--- a/Engine/TestEngine/src/com/redskyit/scriptDriver/RunTests.java
+++ b/Engine/TestEngine/src/com/redskyit/scriptDriver/RunTests.java
@@ -22,6 +22,7 @@ import org.openqa.selenium.By;
 
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Point;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.browserlaunchers.Sleeper;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -693,9 +694,13 @@ public class RunTests {
 			System.out.println();
 			if (null == context) throw new Exception("selected command requires a context at line " + tokenizer.lineno());
 			do {
-				if (_skip || context.isSelected() != _not) {
-					_not = false;
-					return;
+				try {
+					if (_skip || context.isSelected() != _not) {
+						_not = false;
+						return;
+					}
+				} catch(StaleElementReferenceException e) {
+					// element has gone stale, re-select it
 				}
 				sleepAndReselect(100);
 			} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -707,9 +712,13 @@ public class RunTests {
 			System.out.println();
 			if (null == context) throw new Exception("displayed command requires a context at line " + tokenizer.lineno());
 			do {
-				if (_skip || context.isDisplayed() != _not) {
-					_not = false;
-					return;
+				try {
+					if (_skip || context.isDisplayed() != _not) {
+						_not = false;
+						return;
+					}
+				} catch(StaleElementReferenceException e) {
+					// element has gone stale, re-select it
 				}
 				sleepAndReselect(100);
 			} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -740,10 +749,14 @@ public class RunTests {
 						System.out.println();
 						if (null == context) throw new Exception("at command requires a context at line " + tokenizer.lineno());
 						do {
-							Point loc = context.getLocation();
-							if (_skip || ((loc.x == x || x == -1) && loc.y == y) != _not) {
-								_not = false;
-								return;
+							try {
+								Point loc = context.getLocation();
+								if (_skip || ((loc.x == x || x == -1) && loc.y == y) != _not) {
+									_not = false;
+									return;
+								}
+							} catch(StaleElementReferenceException e) {
+								// element has gone stale, re-select it
 							}
 							sleepAndReselect(100);
 						} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -785,10 +798,14 @@ public class RunTests {
 						System.out.println();
 						if (null == context) throw new Exception("size command requires a context at line " + tokenizer.lineno());
 						do {
-							Dimension size = context.getSize();
-							if (_skip || ((mw == -1 || (size.width >= mw && size.width <= w)) && size.height == h) != _not) {
-								_not = false;
-								return;
+							try {
+								Dimension size = context.getSize();
+								if (_skip || ((mw == -1 || (size.width >= mw && size.width <= w)) && size.height == h) != _not) {
+									_not = false;
+									return;
+								}
+							} catch(StaleElementReferenceException e) {
+								// element has gone stale, re-select it
 							}
 							sleepAndReselect(100);
 						} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -809,9 +826,13 @@ public class RunTests {
 				System.out.println();
 				if (null == context) throw new Exception("tag command requires a context at line " + tokenizer.lineno());
 				do {
-					if (_skip || tokenizer.sval.equals(context.getTagName()) != _not) {
-						_not = false;
-						return;
+					try {
+						if (_skip || tokenizer.sval.equals(context.getTagName()) != _not) {
+							_not = false;
+							return;
+						}
+					} catch(StaleElementReferenceException e) {
+						// element has gone stale, re-select it
 					}
 					sleepAndReselect(100);
 				} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -1025,10 +1046,14 @@ public class RunTests {
 			throw new Exception("check value \"" + tokenizer.sval + "\" test failed for current field context at line " + tokenizer.lineno());
 		} else {
 			do {
-				String value = context.getText();
-				if (_not != (null != value && compareStrings(value, tokenizer.sval, checksum))) {
-					_not = false;
-					return;
+				try {
+					String value = context.getText();
+					if (_not != (null != value && compareStrings(value, tokenizer.sval, checksum))) {
+						_not = false;
+						return;
+					}
+				} catch(StaleElementReferenceException e) {
+					// element has gone stale, re-select it
 				}
 				sleepAndReselect(100);
 			} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
@@ -1046,10 +1071,13 @@ public class RunTests {
 					if (set && !tagName.equals("select")) context.clear();
 					context.sendKeys(tokenizer.sval);
 					return;
+				} catch(StaleElementReferenceException se) {
+					// element has gone stale, re-select it
+					e = se;
 				} catch(Exception ex) {
 					e = ex;
-					sleepAndReselect(100);
 				}
+				sleepAndReselect(100);
 			} while (_waitFor > 0 && (new Date()).getTime() < _waitFor);
 			throw new Exception("could not send keys to element " + e.getMessage());
 		} else {
@@ -1064,14 +1092,19 @@ public class RunTests {
 	private void sleepAndReselect(int ms) throws Exception {
 		Sleeper.sleepTight(ms);
 		try {
-			if (ctype == ContextType.XPath) {
+			if (ctype == ContextType.XPath || ctype == ContextType.Field) {
 				context = (RemoteWebElement) driver.findElement(By.xpath(selector));
 			}
 			else if (ctype == ContextType.Select) {
 				context = (RemoteWebElement) driver.findElement(By.cssSelector(selector));
 			}
-			else if (ctype == ContextType.Field) {
-				context = (RemoteWebElement) driver.findElement(By.xpath(selector));
+			else if (ctype == ContextType.Script) {
+				Object result = driver.executeAsyncScript(selector);
+				if (null != result) {
+					if (result.getClass() == RemoteWebElement.class) {
+						context = (RemoteWebElement) result;
+					}
+				}
 			}
 		} catch (Exception e) {
 			throw e;

--- a/tools/mkdist.sh
+++ b/tools/mkdist.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 test ! -d dist -o ! -d tools && { echo "Please run tools/mkdist.sh from root folder" ; exit 1; }
+
+# make sure its built
+cd Engine/TestEngine
+ant || exit $?
+cd ../..
+
+# Build distribution package
 cd dist
 VERSION=0.1
 DIST=ScriptDriver-$VERSION


### PR DESCRIPTION
Handle StaleElementReferenceException(s) and drop into sleepAndReselect logic so that when a reference goes stale because of a refresh between the selector and the test, the new refreshed version of the element will be selected (or not if it no longer exists).